### PR TITLE
Fix for issue 8: wrapping call to removeObserver:forKeyPath: in

### DIFF
--- a/RNActivityView/RNActivityView.m
+++ b/RNActivityView/RNActivityView.m
@@ -642,7 +642,17 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 
 - (void)unregisterFromKVO {
 	for (NSString *keyPath in [self observableKeypaths]) {
-		[self removeObserver:self forKeyPath:keyPath];
+        @try {
+            // This is throwing an exception in iOS 14 beta 6
+            // Wrapping this in a try-catch block to prevent
+            // this from crashing
+            // https://github.com/souzainf3/RNActivityView/issues/8
+            [self removeObserver:self forKeyPath:keyPath];
+        } @catch (NSException *exception) {
+            // Do nothing
+        } @finally {
+            // Do nothing
+        }
 	}
 }
 


### PR DESCRIPTION
A call to removeObserver is crashing in iOS 14 beta 6 because iOS thinks the observer being removed doesn't exist.  This fix wraps the call in a try/catch block to prevent the exception causing a crash. An ideal fix would address the root cause. I've been unable to discover this, hence the try/catch block. The root cause might be a bug in the iOS 14 beta, in which case this solution would be the most appropriate.

https://github.com/souzainf3/RNActivityView/issues/8